### PR TITLE
Improve switching orientation

### DIFF
--- a/app/src/main/java/org/jetbrains/kotlinx/dl/example/app/ImageAnalyzer.kt
+++ b/app/src/main/java/org/jetbrains/kotlinx/dl/example/app/ImageAnalyzer.kt
@@ -9,7 +9,8 @@ import org.jetbrains.kotlinx.dl.onnx.inference.ONNXModelHub
 internal class ImageAnalyzer(
     context: Context,
     private val resources: Resources,
-    private val uiUpdateCallBack: (AnalysisResult?) -> Unit
+    private val uiUpdateCallBack: (AnalysisResult?) -> Unit,
+    initialPipelineIndex: Int = 0
 ) {
     private val hub = ONNXModelHub(context)
 
@@ -20,7 +21,7 @@ internal class ImageAnalyzer(
     private val pipelines = pipelinesList.map { it.createPipeline(hub, resources) }
 
     @Volatile
-    var currentPipelineIndex: Int = 0
+    var currentPipelineIndex: Int = initialPipelineIndex
         private set
     private val currentPipeline: InferencePipeline? get() = pipelines.getOrNull(currentPipelineIndex)
 


### PR DESCRIPTION
By default, Activity is destroyed and created again during orientation switch. This PR fixes problems in connection with this:
1. `OnnxInferenceModel` is not thread-safe and creating/closing and using it on different threads can create race conditions which manifest during orientation switching.
2. Selected pipeline and camera orientation should be preserved when orientation is switched.

Currently ui controls look a bit weird in horizontal mode, need to create a separate horizontal layout in the future. Also, all the models are destroyed and created again on orientation switch, need to find a way to preserve the models.